### PR TITLE
remove split: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^2.0.0",
-		"@sveltejs/adapter-vercel": "^2.4.0",
+		"@sveltejs/adapter-vercel": "^2.4.1",
 		"@sveltejs/kit": "^1.5.0",
 		"autoprefixer": "^10.4.14",
 		"postcss": "^8.4.21",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,26 +28,6 @@
 		<div class="ml-8">&#125;;</div>
 		<div>&#125;;</div>
 	</div>
-	<div class="opacity-80 mb-4">
-		NOTE: In order to do this you must be using the <a
-			class="text-blue-400 hover:text-blue-500"
-			href="https://github.com/sveltejs/kit/tree/master/packages/adapter-vercel"
-			target="_blank"
-			><span class="p-1 bg-zinc-800 rounded-md font-mono text-xs">adapter-vercel</span></a
-		>
-		and you must configure
-		<span class="p-1 bg-zinc-800 rounded-md font-mono text-xs">split: true</span>
-		at the adapter level in
-		<span class="p-1 bg-zinc-800 rounded-md font-mono text-xs">svelte.config.js</span>.
-	</div>
-	<!-- adapter: adapter({
-    split: true
-  }) -->
-	<div class="bg-zinc-800 rounded-md mb-4 h-auto font-mono p-4">
-		<div>adapter: adapter(&#123;</div>
-		<div class="ml-8">split: <span class="text-blue-500">true</span></div>
-		<div>&#125;);</div>
-	</div>
 	<div class="opacity-80">
 		Learn more about using ISR with SvelteKit on Vercel <a
 			class="text-blue-400 hover:text-blue-500"

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,9 +7,7 @@ const config = {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter({
-			split: true
-		})
+		adapter: adapter()
 	},
 	preprocess: vitePreprocess()
 };


### PR DESCRIPTION
This removes the now-unnecessary `split: true` option, and also removes `adapter-auto` since we don't need it