### PR TITLE
a11y fixes

### DIFF
--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -1,7 +1,7 @@
 <div
 	class="max-w-4xl mx-auto w-full flex md:flex-row flex-col items-center md:justify-between py-8 mb-12 border-b border-white/20"
 >
-	<a href="/" class="flex items-center mb-4 md:mb-0 text-white">
+	<a href="/" class="flex items-center mb-4 md:mb-0 text-white" aria-label="Home">
 		<svg height="30" viewBox="0 0 113 100" width="30" xmlns="http://www.w3.org/2000/svg"
 			><defs
 				><linearGradient id="a" x1="196.57%" x2="100%" y1="228.82%" y2="100%"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,11 @@
 	import Footer from '../lib/Footer.svelte';
 </script>
 
+<svelte:head>
+	<title>SvelteKit Deployment Configuration</title>
+	<meta name="description" content="Learn how to configuration your SvelteKit app to use Edge Functions, Serverless Functions, and Incremental Static Regeneration on Vercel" />
+</svelte:head>
+
 <div class="px-8 lg:px-0 h-screen flex flex-col justify-between">
 	<Header />
 	<div class="flex-grow w-full max-w-4xl mx-auto flex flex-col md:flex-row">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 		your <span class="p-1 bg-zinc-800 rounded-md font-mono text-xs">+page.js</span> file:
 	</div>
 	<div class="bg-zinc-800 rounded-md mb-4 h-auto font-mono p-4">
-		<div><span class="text-blue-500">export const</span> config = &#123;</div>
+		<div><span class="text-blue-400">export const</span> config = &#123;</div>
 		<div class="ml-8">runtime: <span class="text-orange-500">'edge'</span></div>
 		<div>&#125;;</div>
 	</div>
@@ -22,7 +22,7 @@
 		Function.
 	</div>
 	<div class="bg-zinc-800 rounded-md mb-4 h-auto font-mono p-4">
-		<div><span class="text-blue-500">export const</span> config = &#123;</div>
+		<div><span class="text-blue-400">export const</span> config = &#123;</div>
 		<div class="ml-8">isr: &#123;</div>
 		<div class="ml-16">expiration: <span class="text-emerald-400">10</span></div>
 		<div class="ml-8">&#125;;</div>
@@ -30,7 +30,7 @@
 	</div>
 	<div class="opacity-80 mb-4">
 		NOTE: In order to do this you must be using the <a
-			class="text-blue-400 hover:text-blue-500"
+			class="text-blue-400 hover:text-blue-400"
 			href="https://github.com/sveltejs/kit/tree/master/packages/adapter-vercel"
 			target="_blank"
 			><span class="p-1 bg-zinc-800 rounded-md font-mono text-xs">adapter-vercel</span></a
@@ -45,14 +45,14 @@
   }) -->
 	<div class="bg-zinc-800 rounded-md mb-4 h-auto font-mono p-4">
 		<div>adapter: adapter(&#123;</div>
-		<div class="ml-8">split: <span class="text-blue-500">true</span></div>
+		<div class="ml-8">split: <span class="text-blue-400">true</span></div>
 		<div>&#125;);</div>
 	</div>
 	<div class="opacity-80">
-		Learn more about using ISR with SvelteKit on Vercel <a
-			class="text-blue-400 hover:text-blue-500"
+		Learn more about <a
+			class="text-blue-400 hover:text-blue-400"
 			href="https://kit.svelte.dev/docs/adapter-vercel#incremental-static-regeneration"
-			target="_blank">here</a
+			target="_blank">using ISR with SvelteKit on Vercel</a
 		>.
 	</div>
 </div>

--- a/src/routes/edge/+page.svelte
+++ b/src/routes/edge/+page.svelte
@@ -12,7 +12,7 @@
 		Runtime which is more performant and cost-effective than Serverless Functions. Edge Functions
 		are deployed globally on an Edge Network, and can automatically execute in the region nearest to
 		the user. Learn more about edge functions <a
-			class="text-blue-400 hover:text-blue-500"
+			class="text-blue-400 hover:text-blue-400"
 			href="https://vercel.com/docs/concepts/functions/edge-functions"
 			target="_blank">here</a
 		>.

--- a/src/routes/isr/+page.svelte
+++ b/src/routes/isr/+page.svelte
@@ -13,7 +13,7 @@
 		developers: better performance, improved security, and faster build times. Learn more about ISR <a
 			href="https://vercel.com/docs/concepts/incremental-static-regeneration/overview#"
 			target="_blank"
-			class="text-blue-400 hover:text-blue-500">here</a
+			class="text-blue-400 hover:text-blue-400">here</a
 		>.
 	</div>
 	<div class="opacity-80 mb-4">


### PR DESCRIPTION
This fixes some a11y warnings in Lighthouse:

* provides alt text for the home link
* adds SEO content
* increases the lightness of the blue highlights
* uses descriptive link text (Lighthouse doesn't like 'here')

Together with #2, this should result in 100s across the board in Lighthouse
